### PR TITLE
chore: Big refactoring

### DIFF
--- a/lib/slaver.rb
+++ b/lib/slaver.rb
@@ -1,4 +1,8 @@
 require 'rails'
+require 'singleton'
+require 'slaver/scope_proxy'
+require 'slaver/config_handler'
+require 'slaver/pools_handler'
 require 'slaver/version'
 require 'slaver/proxy'
 require 'slaver/proxy_methods'

--- a/lib/slaver/config_handler.rb
+++ b/lib/slaver/config_handler.rb
@@ -1,0 +1,46 @@
+module Slaver
+  class ConfigHandler
+    include Singleton
+
+    attr_reader :block, :saved_block, :saved_config, :current_config
+
+    def run_with(klass, config_name, pools_handler)
+      config_name = prepare(config_name)
+
+      pools_handler.for_config(klass, config_name)
+
+      with_config(config_name) { yield }
+    end
+
+    private
+
+    def with_config(config_name)
+      last_config = @current_config
+      @current_config = config_name
+
+      begin
+        yield
+      ensure
+        @current_config = last_config
+      end
+    end
+
+    def prepare(config_name)
+      config_name = config_name.to_s
+
+      return config_name if ::ActiveRecord::Base.configurations.key?(config_name)
+
+      config_name = "#{Rails.env}_#{config_name}"
+
+      unless ::ActiveRecord::Base.configurations.key?(config_name)
+        if Rails.env.production?
+          raise ArgumentError, "Can't find #{config_name} on database configurations"
+        else
+          config_name = Rails.env
+        end
+      end
+
+      config_name
+    end
+  end
+end

--- a/lib/slaver/pools_handler.rb
+++ b/lib/slaver/pools_handler.rb
@@ -1,0 +1,35 @@
+module Slaver
+  class PoolsHandler
+    include Singleton
+
+    def pools
+      @pools ||= {}
+    end
+
+    def for_config(klass, config_name)
+      @klass = klass
+
+      initialize_pool(config_name) unless pools[config_name]
+
+      self
+    end
+
+    private
+
+    def initialize_pool(config_name)
+      if config_name == Rails.env
+        pools[config_name] = @klass.connection_pool_without_proxy
+      else
+        pools[config_name] = create_connection_pool(config_name)
+      end
+    end
+
+    def create_connection_pool(config_name)
+      config = ::ActiveRecord::Base.configurations[config_name]
+      config.symbolize_keys!
+      spec = ActiveRecord::Base::ConnectionSpecification.new(config, "#{config[:adapter]}_connection")
+
+      ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec)
+    end
+  end
+end

--- a/lib/slaver/proxy.rb
+++ b/lib/slaver/proxy.rb
@@ -1,12 +1,12 @@
 module Slaver
   class Proxy
-    attr_accessor :klass, :config
-    attr_reader :connection_pool
+    include Singleton
 
-    def get_connection(klass, config)
+    attr_reader :connection_pool, :klass
+
+    def for_config(klass, config_name)
       @klass = klass
-      @connection_pool = klass.pools[config]
-      @config = config
+      @connection_pool = klass.pools[config_name]
 
       self
     end
@@ -32,14 +32,7 @@ module Slaver
     end
 
     def method_missing(method, *args, &block)
-      klass.clear_config if should_clean?(method)
       safe_connection.send(method, *args, &block)
-    end
-
-    private
-
-    def should_clean?(method)
-      method.to_s =~ /insert|select|execute/ && !klass.within_block?
     end
   end
 end

--- a/lib/slaver/proxy_methods.rb
+++ b/lib/slaver/proxy_methods.rb
@@ -14,49 +14,47 @@ module Slaver
 
     module ClassMethods
       def connection_pool_with_proxy
-        if @current_config
-          connection_proxy.get_connection(self, @current_config).connection_pool
+        if current_config
+          connection_proxy.connection_pool
         else
           connection_pool_without_proxy
         end
       end
 
       def connection_with_proxy
-        if @current_config
-          connection_proxy.get_connection(self, @current_config)
+        if current_config
+          connection_proxy
         else
           (connection_pool && connection_pool.connection)
         end
       end
 
       def clear_active_connections_with_proxy!
-        if @current_config
-          connection_proxy.get_connection(self, @current_config).clear_active_connections!
+        if current_config
+          connection_proxy.clear_active_connections!
         else
           clear_active_connections_without_proxy!
         end
       end
 
       def clear_all_connections_with_proxy!
-        if @current_config
-          connection_proxy.get_connection(self, @current_config).clear_all_connections!
+        if current_config
+          connection_proxy.clear_all_connections!
         else
           clear_all_connections_without_proxy!
         end
       end
 
       def connected_with_proxy?
-        if @current_config
-          connection_proxy.get_connection(self, @current_config).connected?
+        if current_config
+          connection_proxy.connected?
         else
           connected_without_proxy?
         end
       end
 
       def connection_proxy
-        ::ActiveRecord::Base.class_variable_defined?(:@@connection_proxy) &&
-                  ::ActiveRecord::Base.class_variable_get(:@@connection_proxy) ||
-                  ::ActiveRecord::Base.class_variable_set(:@@connection_proxy, Proxy.new)
+        Proxy.instance.for_config(self, current_config)
       end
     end
   end

--- a/lib/slaver/scope_proxy.rb
+++ b/lib/slaver/scope_proxy.rb
@@ -1,0 +1,29 @@
+module Slaver
+  class ScopeProxy
+    attr_reader :klass, :config_name
+
+    def initialize(klass, config_name)
+      @klass = klass
+      @config_name = config_name
+    end
+
+    def on(config_name)
+      @config_name = config_name
+      self
+    end
+
+    def method_missing(method, *args, &block)
+      result = self
+      ::ActiveRecord::Base.within(config_name) do
+        result = klass.send(method, *args, &block)
+
+        if result.is_a?(ActiveRecord::Relation)
+          @klass = result
+          return self
+        end
+      end
+
+      result
+    end
+  end
+end


### PR DESCRIPTION
TL;DR: Я разнел логику из Connection по другим классам, для поддержания single responsibility.

Как было:
1. Вызываем `on`/`within`, сохраняем конфиг(название подключения) в текущем классе в переменной `@current_config` (в другом классе может быть другое значение)
2. Создаем новый пул подключений (если надо) в текущем классе и ложим его в хэш `@pools` относительно `@current_config` (в другом классе может быть другой набор пулов, состоящий из тех же значений )
3. При попытке залезть в базу вызываем проверку на текущий конфиг, которая начила превращатся в супер страшную [тут](https://github.com/abak-press/slaver/pull/2/files#diff-e3cd3a2833978d8433772eb42c1b4a45R101)
4. Если проверка успешная подменяем подключение [проксей](https://github.com/abak-press/slaver/blob/master/lib/slaver/proxy.rb) (синглетон) и используем другой пул на всех методах
5.
 ДЛЯ `on`:
   После вызова на проксе select, insert, exectute очищаем текущую конфигурацию
ДЛЯ `within`: 
  выходим из блока, возвращая предыдущую конфигурацию
6. ПРОФИТ

Что изменилось - 
1) Вызываем `on`, подменяем значение конфига в синглетоне `ConfigHandler`, таким образом в каждый момент времени будет только одна конфигурация, которая определяет какой пул использовать, а не 100500 конфигов распиханные по разным классам.
Т.е. теперь

``` ruby
Foo.within(:other) { .... }
# идетнтично
Bar.within(:other) { .... }
# и идентично
ActiveRecord::Base.within(:other) { .... }
```

2) Создаем пул и сохраняем его в синглетоне `PoolsHandler`, т.к. пул не зависит от класса нет смысла создавать одинаковые пулы в разных классах.

Остальное осталось как есть. Только тепер сразу очевидно, что прокся синглетон.

Названия переменных, как всегда, так себе.. Can you help me with that, guys?:smile:

UPDATE AFTER EPIC FAIL FIX:
Теперь `on` метод работает через ActiveRecord::Base.within, используя `ScopeProxy`, которая перенаправляет все непонятные методы в класс на котором был вызван `on` выполняя их в блоке `within`.
