### PR TITLE
feature: slaver_establish_connection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ Some.class_method
 Some.new.some_method
 ```
 
+### Switch all ActiveRecord::Base method to slave for specific class
+Allows you to make connection to database permanent. After that change `on` or `within` won't change database connection on execution.
+```
+class SomeModel < ActiveRecord::Base
+  # behaves exacly as AR - establish_connection
+  slaver_establish_conenction :test_other
+end
+
+# except one little thing:
+SomeModel.within(:test) do
+  SomeModel.create # It'll execute on :test_other connection, because it'll ignore slaver dynamic connection change
+end
+
+```
+
 ### ACHTUNG!!!!
 
 If you connection does not exists, behavior may change dependent of you current Rails environment:

--- a/lib/slaver/connection.rb
+++ b/lib/slaver/connection.rb
@@ -73,6 +73,24 @@ module Slaver
         config_handler.run_with(self, config_name, pools_handler) { yield }
       end
 
+      # Public: Permanent change of connection for AR model
+      #
+      # config_name - String or Symbol, name of config_section
+      #
+      # Examples
+      #
+      #   SomeModel.switch_class :other
+      #
+      #   SomeModel.on(:test).connection - will return connection to other!!
+      #
+      #   SomeModel.switch_class :other, true
+      #
+      # Returns ConnectionPool
+      def slaver_establish_connection(config_name)
+        @ignore_slaver = true
+        establish_connection config_name
+      end
+
       private
 
       def config_handler

--- a/lib/slaver/proxy_methods.rb
+++ b/lib/slaver/proxy_methods.rb
@@ -14,7 +14,7 @@ module Slaver
 
     module ClassMethods
       def connection_pool_with_proxy
-        if current_config
+        if use_proxy?
           connection_proxy.connection_pool
         else
           connection_pool_without_proxy
@@ -22,7 +22,7 @@ module Slaver
       end
 
       def connection_with_proxy
-        if current_config
+        if use_proxy?
           connection_proxy
         else
           (connection_pool && connection_pool.connection)
@@ -30,7 +30,7 @@ module Slaver
       end
 
       def clear_active_connections_with_proxy!
-        if current_config
+        if use_proxy?
           connection_proxy.clear_active_connections!
         else
           clear_active_connections_without_proxy!
@@ -38,7 +38,7 @@ module Slaver
       end
 
       def clear_all_connections_with_proxy!
-        if current_config
+        if use_proxy?
           connection_proxy.clear_all_connections!
         else
           clear_all_connections_without_proxy!
@@ -46,11 +46,15 @@ module Slaver
       end
 
       def connected_with_proxy?
-        if current_config
+        if use_proxy?
           connection_proxy.connected?
         else
           connected_without_proxy?
         end
+      end
+
+      def use_proxy?
+        !@ignore_slaver && current_config
       end
 
       def connection_proxy

--- a/spec/lib/slaver_spec.rb
+++ b/spec/lib/slaver_spec.rb
@@ -286,4 +286,26 @@ describe Slaver do
       end
     end
   end
+
+  describe '#slaver_establish_connection' do
+    let(:result) { ActiveRecord::Base.on(:other).connection.execute('select * from foos;') }
+
+    it 'switches class to other connection' do
+      Foo.slaver_establish_connection(:test_other)
+
+      Foo.create
+
+      expect(result).not_to be_empty
+    end
+
+    it "does not use slaver if it wasn't required" do
+      Foo.slaver_establish_connection(:test_other)
+
+      ActiveRecord::Base.within(:test) do
+        Foo.create
+      end
+
+      expect(result).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
AKA еще один велик из октопуса...

Проблема:

``` ruby
class SomeModel < ActiveRecord::Base
  establish_connection :other
end

def some_method
   SomeModel.create # Хотим чтобы это исполнялось на other, но оно выполнится на slave
end
switch :some_model, to: :slave
```

Решение:

``` ruby
class SomeModel < ActiveRecord::Base
  slaver_establish_connection :other
end

def some_method
   SomeModel.create # Выполнится на other, методы slaver'а будут игнорироваться
end
switch :some_model, to: :slave
```
