### PR TITLE
fix: add missed definition for Slaver::Proxy#respond_to_missing?

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,26 +1,37 @@
 matrix:
   include:
-    - DOCKER_RUBY_VERSION: 1.9.3
-      RUBY_IMAGE_TAG: 1.9.3-2
-
     - DOCKER_RUBY_VERSION: 2.2
-      RUBY_IMAGE_TAG: 2.2-2
+      RUBY_IMAGE_TAG: 2.2-latest
+
+    - DOCKER_RUBY_VERSION: 2.3
+      RUBY_IMAGE_TAG: 2.3-latest
 
 build:
-  image: abakpress/dind:2
+  image: abakpress/dind-testing
   privileged: true
   volumes:
     - /home/data/drone/images:/images
     - /home/data/drone/gems:/bundle
   environment:
     - COMPOSE_FILE_EXT=drone
+    - RAILS_ENV=test
+    - RUBY_IMAGE_TAG=2.2-latest
   commands:
     - wrapdocker docker -v
 
-    - if [ ! -e /images/ruby_$RUBY_IMAGE_TAG.tar ]; then docker pull abakpress/ruby:$RUBY_IMAGE_TAG; docker save abakpress/ruby:$RUBY_IMAGE_TAG > /images/ruby_$RUBY_IMAGE_TAG.tar; fi
-
-    - docker load -i /images/ssh-agent.tar
-    - docker load -i /images/ruby_$RUBY_IMAGE_TAG.tar
+    - fetch-images
+      --image abakpress/ruby-app:$RUBY_IMAGE_TAG
 
     - dip provision
     - dip rspec
+
+  release:
+    image: abakpress/gem-publication
+    pull: true
+    when:
+      event: push
+      branch: master
+    volumes:
+      - /home/data/drone/rubygems:/root/.gem
+    commands:
+      - release-gem --public

--- a/Appraisals
+++ b/Appraisals
@@ -1,19 +1,14 @@
-appraise 'rails3.1' do
-  gem 'rails', '~> 3.1.0'
-end if RUBY_VERSION < '2'
-
-appraise 'rails3.2' do
-  gem 'rails', '~> 3.2.0'
-end
-
 appraise 'rails4.0' do
   gem 'rails', '~> 4.0.0'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 appraise 'rails4.1' do
   gem 'rails', '~> 4.1.0'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 appraise 'rails4.2' do
   gem 'rails', '~> 4.2.0'
+  gem 'sqlite3', '~> 1.3.6'
 end

--- a/dip.yml
+++ b/dip.yml
@@ -1,8 +1,8 @@
 version: '1'
 
 environment:
-  DOCKER_RUBY_VERSION: 1.9.3
-  RUBY_IMAGE_TAG: 1.9.3-2
+  DOCKER_RUBY_VERSION: 2.2
+  RUBY_IMAGE_TAG: 2.2-latest
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test
 

--- a/docker-compose.drone.yml
+++ b/docker-compose.drone.yml
@@ -5,4 +5,3 @@ services:
     volumes:
       - .:/app
       - /bundle:/bundle
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,8 @@ version: '2'
 
 services:
   app:
-    image: abakpress/ruby:$RUBY_IMAGE_TAG
+    image: abakpress/ruby-app:$RUBY_IMAGE_TAG
     environment:
-      - SSH_AUTH_SOCK=/ssh/auth/sock
       - BUNDLE_PATH=/bundle/$DOCKER_RUBY_VERSION
+      - BUNDLE_CONFIG=/app/.bundle/config
     command: bash
-

--- a/lib/slaver/proxy.rb
+++ b/lib/slaver/proxy.rb
@@ -34,5 +34,9 @@ module Slaver
     def method_missing(method, *args, &block)
       safe_connection.send(method, *args, &block)
     end
+
+    def respond_to_missing?(method, include_private = false)
+      safe_connection.respond_to?(method, include_private) || super
+    end
   end
 end

--- a/lib/slaver/version.rb
+++ b/lib/slaver/version.rb
@@ -1,3 +1,3 @@
 module Slaver
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'.freeze
 end

--- a/slaver.gemspec
+++ b/slaver.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', '>= 3.1.0', '< 5.0'
-  spec.add_runtime_dependency 'activesupport', '>= 3.1.0', '< 5.0'
+  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 5.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.0', '< 5.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/spec/lib/slaver/proxy_spec.rb
+++ b/spec/lib/slaver/proxy_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Slaver::Proxy do
+  describe 'connection methods delegation' do
+    context 'when proxy connection does not respond to called method' do
+      it 'does not respond and raises NameError' do
+        expect(Foo.on(:other).connection.respond_to?(:not_existed_method)).to eq(false)
+        expect { Foo.on(:other).connection.method(:not_existed_method) }.to raise_error(NameError)
+        expect { Foo.on(:other).connection.not_existed_method }.to raise_error(NameError)
+      end
+    end
+
+    context 'when proxy connection responds to called method' do
+      let(:query) { "SELECT COUNT(*) FROM #{Foo.quoted_table_name} WHERE name = 'other_1'" }
+
+      it 'responds to method by calling it on proxy connection' do
+        Foo.on(:other).create!(name: 'other_1')
+        Foo.on(:other).create!(name: 'other_2')
+
+        expect(Foo.on(:other).connection.respond_to?(:select_value)).to eq(true)
+        expect(Foo.on(:other).connection.method(:select_value)).to be
+        expect(Foo.on(:other).connection.select_value(query).to_i).to eq(1)
+        expect(Foo.connection.select_value(query).to_i).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Пробовал поднять заказы на rails 4.1 - 4.2, падают миграции с ошибками вида `undefined method 'execute' for <#MyMigration>`. Дело в том, что в наших миграциях используется slaver для прогона тестов в разных базах, метод `execute` в миграции [ищется](https://github.com/rails/rails/blob/0cad778c2605a5204a05a9f1dbd3344e39f248d8/activerecord/lib/active_record/migration.rb#L645) в доступных методах `connection`, а он в данном случае = `Slaver::Proxy.instance`, и `respond_to?` вызывается на нем. Необходимо проверять доступность методов у `Slaver::Proxy#safe_connection`.

https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding

Заодно убрал старые рельсы-руби